### PR TITLE
Allow evaluating a single Route 53 zone without touching others

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Usage: dynroute [options]
 
 Options:
    -d, --domain          Domain(s) to update [required] (you can specify multiple domains, ex: -d ro.domain.com -d en.domain.com)
+   -z, --zone            Route 53 Zone ID that the domain lives in [default: searches all zones for domain]
    -ttl, --ttl           Time To Leave (in seconds) [default: 60]
    -t, --time            How frequently to check for IP update [default: 60]
    -o, --once            Check for IP update ONLY ONCE and exit [default: false]

--- a/bin/dynroute
+++ b/bin/dynroute
@@ -16,6 +16,11 @@ opts = opts.script('dynroute')
     help     : 'Domain(s) to update [required]',
     list: true
   })
+  .option('zone', {
+    abbr     : 'z',
+    required : false,
+    help     : 'Route 53 Zone ID that the domain lives in [default: searches all zones for domain]'
+  })
   .option('ttl', {
     abbr    : 'ttl',
     default : 60,

--- a/dynroute.js
+++ b/dynroute.js
@@ -36,6 +36,15 @@ function searchRecord(ip) {
     }
 
     async.map(hostedZones, function(zone, callback) {
+      // skip listing record sets and return an empty array unless we care about this specific zone
+      if (opts.zone && opts.zone !== zone.id) {
+        callback(null, {
+          id: zone.id,
+          records: []
+        });
+        return;
+      }
+
       r53.ListResourceRecordSets({ HostedZoneId : zone.id }, function(err, data) {
         var resp, records;
 


### PR DESCRIPTION
So I ran into a problem where I wanted to limit access of the IAM user this script was using to a specific hosted zone, but it wants to iterate through all the available zones. Since I already know the zone ID I want, I set up an option to take a zone ID. If present, it skip listing record sets on the other zones.

Ideally, I would have avoided the `ListHostedZones` call altogether and just used `GetHostedZone`, but this was a simple change to allow what I needed without restructuring the whole lib.
